### PR TITLE
Add unicode and glob pattern support

### DIFF
--- a/tid2md.py
+++ b/tid2md.py
@@ -309,7 +309,6 @@ def migrate_tid_file(
         return False
 
     try:
-        print("trying to open", tid_file)
         with open(tid_file, encoding='UTF-8') as f:
             lines = f.readlines()
     except IOError as error:


### PR DESCRIPTION
This PR adds unicode decoding and encoding to all `open`s in order to support Unicode characters in tiddlers, and also replaces the pathlib file args with raw paths that are globbed over.

The suggested use in readme.md (`tid2md.py -d *.tid`) raised an error stating that *.tid is an invalid path. I assumed patterns would be supported, and I had over 100 tiddlers, so I certainly wasn't going to compile a list of names to feed to the script. Dunno whether it was because I was running it on windows, but as far as I could tell, the script didn't actually support patterns. Sorry if I missed something, been some years since I used python for anything and I've not got the time.

With this fix, I could actually do `python .\tid2md.py -d *.tid` from PS just fine. It's a little bit of butchery, but it works. Also set encodings to UTF-8, I got some tiddlers containing certain specific characters. (Unicode filenames are not an issue, fortunately, as .tids and thus their corresponding .mds don't use unicode characters in their names.)

Cheers for the script otherwise, you're a lifesaver. It's flabbergasting that something like this (exporting/importing) isn't native functionality of the tiddly markdown plugin.