### PR TITLE
Add unicode and pattern support (proper)

### DIFF
--- a/tid2md.py
+++ b/tid2md.py
@@ -24,6 +24,7 @@ import subprocess
 import urllib.parse
 from pathlib import Path
 from typing import TextIO
+from glob import glob
 
 
 re_special_tag = re.compile(r'^tags:.*\$:/tags/')
@@ -92,7 +93,7 @@ def write_meta_file(lines: list, meta_file: Path) -> int:
 
     type_defined = False
     try:
-        with open(meta_file, 'w') as f:
+        with open(meta_file, 'w', encoding='UTF-8') as f:
             for index, line in enumerate(lines):
                 if re.match(r'[a-z]+:', line):
                     if line.startswith('type:'):
@@ -128,7 +129,7 @@ def write(f: TextIO, line: str, quoted: bool = False):
 def write_markdown_file(lines: list, md_file: Path) -> bool:
     try:
         print(md_file.name)
-        with open(md_file, 'w') as f:
+        with open(md_file, 'w', encoding='UTF-8') as f:
             codeblock = False
             blockquote = False
             table = False
@@ -308,7 +309,7 @@ def migrate_tid_file(
         return False
 
     try:
-        with open(tid_file) as f:
+        with open(tid_file, encoding='UTF-8') as f:
             lines = f.readlines()
     except IOError as error:
         error(err)
@@ -344,7 +345,7 @@ def migrate_tid_file(
     return result
 
 
-def main(tid_files: list = None, update: bool = False,
+def main(tid_file_paths: list = None, update: bool = False,
          delete_input: bool = False, output_directory: Path = None,
          tables: bool = False):
     skip_count = 0
@@ -354,18 +355,25 @@ def main(tid_files: list = None, update: bool = False,
     if output_directory and not output_directory.is_dir():
         error(f"The output directory '{output_directory}' does not exist!")
         sys.exit(1)
+        
+    tid_files = []
+    for path in tid_file_paths:
+        for file in glob(path):
+            tid_files.append(file)
 
     for tid_file in tid_files:
-        if tid_file.name.startswith('$__'):
-            warning(f"'{tid_file.name}' looks like a system tiddler. "
+        if tid_file.startswith('$__'):
+            warning(f"'{tid_file}' looks like a system tiddler. "
                     "Skipping it.")
             skip_count += 1
             continue
-        if migrate_tid_file(tid_file, update, output_directory, tables):
+            
+        tid_path = Path(tid_file)
+        if migrate_tid_file(tid_path, update, output_directory, tables):
             # TODO: Delete if migration was skipped because of existing
             # markdown file?
             if delete_input:
-                tid_file.unlink()
+                tid_path.unlink()
             migrate_count += 1
         else:
             skip_count += 1
@@ -389,7 +397,6 @@ if __name__ == '__main__':
                         default=None,
                         help="Write markdown files in this directory.")
     parser.add_argument("files", nargs='+',
-                        type=Path,
                         help=".tid files to migrate to Markdown.")
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR adds unicode decoding and encoding to all `open`s in order to support Unicode characters in tiddlers, and also replaces the pathlib file args with raw paths that are globbed over.

The suggested use in readme.md (`tid2md.py -d *.tid`) raised an error stating that *.tid is an invalid path. I assumed patterns would be supported, and I had over 100 tiddlers, so I certainly wasn't going to compile a list of names to feed to the script. Dunno whether it was because I was running it on windows, but as far as I could tell, the script didn't actually support patterns. Sorry if I missed something, been some years since I used python for anything and I've not got the time.

With this fix, I could actually do `python .\tid2md.py -d *.tid` from PS just fine. It's a little bit of butchery, but it works. Also set encodings to UTF-8, I got some tiddlers containing certain specific characters. (Unicode filenames are not an issue, fortunately, as .tids and thus their corresponding .mds don't use unicode characters in their names.)

Cheers for the script otherwise, you're a lifesaver. It's flabbergasting that something like this (exporting/importing) isn't native functionality of the tiddly markdown plugin.