### PR TITLE
Fixes URL processing for named external and internal links

### DIFF
--- a/tid2md.py
+++ b/tid2md.py
@@ -127,7 +127,7 @@ def parse_link(match):
     label = match.group(1)
     is_named = match.group(2) is not None
     target = match.group(2) if is_named else match.group(1)
-    is_external = "://" in target or target.startswith("www.")
+    is_external = "://" in target
     
     if is_external:
         return f"[{label}]({target})" if is_named else f"<{target}>"

--- a/tid2md.py
+++ b/tid2md.py
@@ -13,7 +13,7 @@ cell merging, ...), just use the --tables flag.
 """
 
 __version__ = '0.3.0'
-__author__ = 'Max Schillinger'
+__author__ = 'Max Schillinger'  # Additional fixes by Lumos
 __email__ = 'maxschillinger@web.de'
 
 import sys
@@ -29,7 +29,8 @@ from typing import TextIO
 re_special_tag = re.compile(r'^tags:.*\$:/tags/')
 re_special_title = re.compile(r'^title: ?\$:/')
 re_external_link = re.compile(r'\[\[(https?://[^\]]+)\]\]')
-re_named_external_link = re.compile(r'\[\[([^|]+)\|([^\]]+)\]\]')
+re_named_external_link = re.compile(r'\[\[([^|\]]+)\|(https?://[^\]]+)\]\]')
+re_named_internal_link = re.compile(r'\[\[([^|\]]+)\|([^\]]+)\]\]')
 re_internal_link = re.compile(r'\[\[([^|]+?)\]\]')
 re_image = re.compile(r'\[img( width=(\d+))? ?\[([^]]+?)\]\]')
 re_url = re.compile(r'(^|[^("<])(https?://[\w#/@:._?%=+-]+)($|[^)">])')
@@ -188,6 +189,12 @@ def write_markdown_file(lines: list, md_file: Path) -> bool:
                     line
                 )
                 # [[internal link|Tiddler]] → [internal link](#Tiddler)
+                line = re_named_internal_link.sub(
+                    lambda m: (
+                        f'[{m.group(1)}](#{urllib.parse.quote(m.group(2))})'
+                    ),
+                    line
+                )
                 # plain url
                 line = re_url.sub(r'\1<\2>\3', line)
 

--- a/tid2md.py
+++ b/tid2md.py
@@ -123,7 +123,7 @@ def write(f: TextIO, line: str, quoted: bool = False):
     f.write(line)
     
     
-def parse_link(match: re.Match):
+def parse_link(match: re.Match) -> str:
     label = match.group(1)
     is_named = match.group(2) is not None
     target = match.group(2) if is_named else match.group(1)

--- a/tid2md.py
+++ b/tid2md.py
@@ -123,7 +123,7 @@ def write(f: TextIO, line: str, quoted: bool = False):
     f.write(line)
     
     
-def parse_link(match):
+def parse_link(match: re.Match):
     label = match.group(1)
     is_named = match.group(2) is not None
     target = match.group(2) if is_named else match.group(1)


### PR DESCRIPTION
Fixes #3.

With this PR, the test tiddler (fortified with external links)
> ```This is a test tiddler that features an [[internal link]] followed by another [[different link]] and then by a [[third one|named link]], then by some random text that really doesn't matter at all. If we throw a named link here [[like this|another named link]] it's fine, but a named link after a [[normal link]] will be ruined. This tiddler gets mangled by the regular expressions. For good measure, we'll throw in some URLs, like this: [[https://github.com]] or why not [[a named tiddlywiki url|https://tiddlywiki.com]]? We'll intersperse them with a few more [[internal link]]s and another  external [[https://github.com]] just to be safe, before we end with the same [[named url with a different name|https://tiddlywiki.com]].```

... is now processed to
> ```This is a test tiddler that features an [internal link](#internal%20link) followed by another [different link](#different%20link) and then by a [third one](#named%20link), then by some random text that really doesn't matter at all. If we throw a named link here [like this](#another%20named%20link) it's fine, but a named link after a [normal link](#normal%20link) will be ruined. This tiddler gets mangled by the regular expressions. For good measure, we'll throw in some URLs, like this: <https://github.com> or why not [a named tiddlywiki url](https://tiddlywiki.com)? We'll intersperse them with a few more [internal link](#internal%20link)s and another  external <https://github.com> just to be safe, before we end with the same [named url with a different name](https://tiddlywiki.com).```

... which appears to fix the mangling.

Note that the regexes matching against http(s) will still fail for all other protocols, but that's out of scope of this PR (and I personally don't have a use case for supporting that).
